### PR TITLE
Add bottle information to 5.56.0 formula

### DIFF
--- a/Formula/cbmc@5.56.0.rb
+++ b/Formula/cbmc@5.56.0.rb
@@ -6,6 +6,15 @@ class CbmcAT5560 < Formula
       revision: "8a41865d97e180e3ca8e4049ee7978b07e428359"
   license "BSD-4-Clause"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "85619ee760a4ab965abc0e47fc95ac45ce4b1295aedb0af4c417b37911937b2d"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "51ac275382706629596c1baae97b3d4b72c94936ad05ae395b9dc52c3bf62c41"
+    sha256 cellar: :any_skip_relocation, monterey:       "ccea3e2d18345638e55b55001e0d0a2137767e162f5a95be10ff7c0e671b4be2"
+    sha256 cellar: :any_skip_relocation, big_sur:        "b487ee987585d20bd84094792813da20fa40fff1961aece0ce08f2f7bded5468"
+    sha256 cellar: :any_skip_relocation, catalina:       "fbcd8d72bda066b86f3839bd6bb82394f99fb1aff7bc05aeb5b1aaa1a9ba7663"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "730cef671dfb7fd549a86cf7266d075b66fc2417f702c553f5fe7c8a60a5b8eb"
+  end
+
   depends_on "cmake" => :build
   depends_on "maven" => :build
   depends_on "openjdk" => :build


### PR DESCRIPTION
It looks like omitting the bottle information done in the second commit of #1 causes CBMC to be built from source: https://docs.brew.sh/Bottles

This causes the CI time for Kani to go up from 22 minutes to 44 minutes: https://github.com/model-checking/kani/runs/6374211806?check_suite_focus=true#step:3:198

So, requesting that we add back the bottle information to at least the 5.56.0 formula so that doing a `brew install diffblue/cbmc/cbmc@5.56.0` is quick.